### PR TITLE
map the role SilvupleLanguageReader to the permisson silvuple: ViewIn…

### DIFF
--- a/silvuple/profiles/default/rolemap.xml
+++ b/silvuple/profiles/default/rolemap.xml
@@ -7,6 +7,7 @@
 
   <permissions>
     <permission name="silvuple: ViewInSilvupleLanguage" acquire="False">
+    <role name="SilvupleLanguageReader"/>
     </permission>
   </permissions>
 


### PR DESCRIPTION
Hi again, mapping the role SilvupleLanguageReader to the permission makes it easier for the user of this add-on